### PR TITLE
Come back link to doorkeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ginza.rb のミートアップ記録用のリポジトリです。wiki に情報
 
 各SNS等へのリンクは以下の通りです。
 
+* [doorkeeper](http://ginzarb.doorkeeper.jp/)
 * [Slack](https://ginzarb.slack.com/messages/general/)([初めての方はこちら](https://ginzarb-slackin.herokuapp.com/))
-* [idobata](https://idobata.io/organizations/ginzarb/rooms/ginzarb/join_request/3cddf7e0-2e26-40e9-8957-31155bf22fc2)
 * [facebook group](https://www.facebook.com/groups/627710653924920/)
 * [twitter](https://twitter.com/ginzarb2)


### PR DESCRIPTION
https://github.com/ginzarb/meetups/pull/478 で doorkeeper へのリンクが消えてしまっていたようなので復活させてみました。 